### PR TITLE
Add health and dynamited log streams. 

### DIFF
--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -1,64 +1,82 @@
 package conf
 
 import (
-	"gopkg.in/yaml.v2"
 	"fmt"
-    "os"
+	"os"
+
+	"gopkg.in/yaml.v2"
 )
 
 var (
-	Conf Config
+	// Conf holds dynamited's current configuration settings
+	Conf    Config
+	roleMap = map[string]string{
+		"agent":   "Inspects network traffic.",
+		"monitor": "Ingests and analyzes events.",
+		"scanner": "Fingerprints network devices.",
+	}
 )
 
+// Config defines the structure and field names for the dynamited config file
 type Config struct {
-    Watcher struct {
-        Interval    string     `yaml:"interval"`
-        Mode        string  `yaml:"mode"` 
-        Enabled     bool  `yaml:"enabled"` 
-    } `yaml:"watcher"`
-    Scanner struct {
-        Targets []string `yaml:"targets"`
-        Interval string `yaml:"interval"`
-        Directory string `yaml:"directory"`
-        Exclusions []string `yaml:"exclusions"`
-        Opts []string `yaml:"opts"`
-    } `yaml:"scanner"`
-    Roles []string `yaml:"roles"`      
-    LogLevel string `yaml:"log_level"`
-    LogDir string `yaml:"log_dir"`
+	Watcher struct {
+		Interval string `yaml:"interval"`
+		Mode     string `yaml:"mode"`
+		Enabled  bool   `yaml:"enabled"`
+	} `yaml:"watcher"`
+	Scanner struct {
+		Targets    []string `yaml:"targets"`
+		Interval   string   `yaml:"interval"`
+		Directory  string   `yaml:"directory"`
+		Exclusions []string `yaml:"exclusions"`
+		Opts       []string `yaml:"opts"`
+	} `yaml:"scanner"`
+	Roles    []string `yaml:"roles"`
+	LogLevel string   `yaml:"log_level"`
+	LogDir   string   `yaml:"log_dir"`
 }
 
-// Method for testing role membership 
-func (c *Config) HasRole(s string)(bool) {
-    for _, a := range c.Roles {
-        if a == s {
-            return true
-        }
-    }
-    return false
+// HasRole returns true if dynamited is configured to run the given role
+func (c *Config) HasRole(s string) bool {
+	for _, a := range c.Roles {
+		if a == s {
+			return true
+		}
+	}
+	return false
 }
 
-func Load(s string)() {
-    readFile(s, &Conf)
+// Load initializes the conf.Conf variable with settings from the config file
+func Load(s string) {
+	readFile(s, &Conf)
 }
 
 func readFile(s string, cfg *Config) {
-    _, err := os.Stat(s)
-    if os.IsNotExist(err) {
-        fmt.Printf("Config file %v not found. Exiting.\n", s)
-        os.Exit(1)
-    }
-    f, ferr := os.Open(s)
-    if ferr != nil {
-        fmt.Printf("Unable to open config file %v. Exiting.\n", s)
-        os.Exit(1)
-    }
-    defer f.Close()
+	_, err := os.Stat(s)
+	if os.IsNotExist(err) {
+		fmt.Printf("Config file %v not found. Exiting.\n", s)
+		os.Exit(1)
+	}
+	f, ferr := os.Open(s)
+	if ferr != nil {
+		fmt.Printf("Unable to open config file %v. Exiting.\n", s)
+		os.Exit(1)
+	}
+	defer f.Close()
 
-    decoder := yaml.NewDecoder(f)
-    derr := decoder.Decode(cfg)
-    if derr != nil {
-        fmt.Printf("Unable to parse config file %v. Exiting.\n", s)
-        os.Exit(1)
-    }
-} 
+	decoder := yaml.NewDecoder(f)
+	derr := decoder.Decode(cfg)
+	if derr != nil {
+		fmt.Printf("Unable to parse config file %v. Exiting.\n", s)
+		os.Exit(1)
+	}
+	rls := []string{}
+	if len(cfg.Roles) > 0 {
+		for _, v := range cfg.Roles {
+			if _, ok := roleMap[v]; ok {
+				rls = append(rls, v)
+			}
+		}
+		cfg.Roles = rls
+	}
+}

--- a/pkg/watcher/agent.go
+++ b/pkg/watcher/agent.go
@@ -1,8 +1,8 @@
 package watcher
 
 import (
-	"strings"
 	"context"
+	"strings"
 
 	// Dynamite
 	"dynamite_daemon_core/pkg/common"
@@ -14,7 +14,7 @@ var (
 	fails = 0
 )
 
-// Run Agent monitoring tasks
+// WatchAgent starts Dynamite Agent monitoring tasks
 func WatchAgent(ctx context.Context, log *logging.Entry, quitting *chan []byte) {
 
 	// start := time.Now()
@@ -41,7 +41,7 @@ func WatchAgent(ctx context.Context, log *logging.Entry, quitting *chan []byte) 
 				e = strings.Split(e, "::")[1]
 				ifaces[e] = struct{}{}
 			}
-		}	
+		}
 	}
 
 	if len(ifaces) > 0 {
@@ -51,19 +51,19 @@ func WatchAgent(ctx context.Context, log *logging.Entry, quitting *chan []byte) 
 			if ifrpt != nil {
 				rptmap := common.StructToMap(ifrpt)
 				log.WithFields(rptmap).Info("interface_stats")
-				fails = 0 
+				fails = 0
 			}
 		}
 	} else {
 		log.Debug("Unable to retrieve inspection interfaces. Trying again.")
-		fails += 1
+		fails++
 	}
 
 	if fails > 5 {
 		*quitting <- []byte("Failed to identify inspection interfaces for 5 consecutive intervals.")
 	}
 
-	// 
+	//
 	if conf.Conf.Watcher.Mode != "" {
 		rr := NewRR()
 		switch conf.Conf.Watcher.Mode {
@@ -71,50 +71,50 @@ func WatchAgent(ctx context.Context, log *logging.Entry, quitting *chan []byte) 
 			//engine
 			rr.RptAEngines()
 			if len(rr.EngRpts) > 0 {
-				for _,v := range rr.EngRpts {
+				for _, v := range rr.EngRpts {
 					log.WithFields(v).Info("engine_stats")
 				}
-			}					
+			}
 		case "process":
 			//engine
 			rr.RptAEngines()
 			if len(rr.EngRpts) > 0 {
-				for _,v := range rr.EngRpts {
+				for _, v := range rr.EngRpts {
 					log.WithFields(v).Info("engine_stats")
 				}
 			}
 			//proc
 			rr.RptAProcs()
 			if len(rr.ProcRpts) > 0 {
-				for _,v := range rr.ProcRpts {
+				for _, v := range rr.ProcRpts {
 					log.WithFields(v).Info("proc_stats")
 				}
 			}
-			
+
 		case "thread":
 			//engine
 			rr.RptAEngines()
 			if len(rr.EngRpts) > 0 {
-				for _,v := range rr.EngRpts {
+				for _, v := range rr.EngRpts {
 					log.WithFields(v).Info("engine_stats")
 				}
 			}
 			//proc
 			rr.RptAProcs()
 			if len(rr.ProcRpts) > 0 {
-				for _,v := range rr.ProcRpts {
+				for _, v := range rr.ProcRpts {
 					log.WithFields(v).Info("proc_stats")
 				}
 			}
 			//thread
 			rr.RptAThreads()
 			if len(rr.ThrdRpts) > 0 {
-				for _,v := range rr.ThrdRpts {
+				for _, v := range rr.ThrdRpts {
 					log.WithFields(v).Info("thread_stats")
 				}
 			}
 		}
-	} 
+	}
 
 	return
 }

--- a/pkg/watcher/agent.go
+++ b/pkg/watcher/agent.go
@@ -34,7 +34,7 @@ func WatchAgent(ctx context.Context, log *logging.Entry, quitting *chan []byte) 
 
 	zeek, err := GetZeekConf()
 	if err != nil {
-		log.Error(err)
+		logging.LogEntry.WithField("pkg", "agent").Error(err)
 	} else {
 		if zeek.Ifaces != nil && len(zeek.Ifaces) > 0 {
 			for _, e := range zeek.Ifaces {
@@ -55,7 +55,7 @@ func WatchAgent(ctx context.Context, log *logging.Entry, quitting *chan []byte) 
 			}
 		}
 	} else {
-		log.Debug("Unable to retrieve inspection interfaces. Trying again.")
+		logging.LogEntry.WithField("pkg", "agent").Debug("Unable to retrieve inspection interfaces. Trying again.")
 		fails++
 	}
 

--- a/pkg/watcher/health.go
+++ b/pkg/watcher/health.go
@@ -1,0 +1,100 @@
+package watcher
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/shirou/gopsutil/load"
+	"github.com/shirou/gopsutil/cpu"
+	"github.com/shirou/gopsutil/disk"
+	"github.com/shirou/gopsutil/mem"
+	"github.com/shirou/gopsutil/host"
+
+	. "dynamite_daemon_core/pkg/common"
+	//"dynamite_daemon_core/pkg/conf"
+	"dynamite_daemon_core/pkg/logging"
+)
+
+// 
+func WatchHealth(ctx context.Context, log *logging.Entry, quitting *chan []byte) {
+
+	// start := time.Now()
+	hinfo, err := host.Info()
+	if err != nil {
+		fmt.Println("Unable to retrieve host information.")
+		*quitting <- []byte("Health watcher exiting!!")
+		return
+	} else {
+		log.WithFields(StructToMap(hinfo)).Info("host_info")	
+	}
+
+	// CPU STATS
+	ccount, err:= cpu.Counts(true)
+	if err != nil {
+		fmt.Println("Unable to retrieve the cpu core count.")
+		*quitting <- []byte("Health watcher exiting!!")		
+		return 
+	} 
+
+	lavg, err := load.Avg()
+	if err != nil {
+		fmt.Println("Unable to retrieve the cpu load average.")
+		*quitting <- []byte("Health watcher exiting!!")
+		return
+	} else {
+		if ccount > 0 {
+			log.WithFields(StructToMap(lavg)).WithField("cpu_cores", ccount).Info("cpu_load_avg")	
+		} else {
+			log.WithFields(StructToMap(lavg)).Info("cpu_load_avg")
+		}
+	}
+
+	ctimes, err := cpu.Times(true)
+	if err != nil {
+		fmt.Println("Unable to retrieve the cpu times.")
+		*quitting <- []byte("Health watcher exiting!!")
+		return 
+	} else {
+		for _, v := range ctimes {
+			log.WithFields(StructToMap(v)).Info("cpu_times")
+		}
+	}
+		
+	// Memory 
+	mem, err := mem.VirtualMemory()
+	if err != nil {
+		fmt.Println("Unable to retrieve RAM stats.")
+		*quitting <- []byte("Health watcher exiting!!")
+		return 
+	} else {
+		log.WithFields(StructToMap(mem)).Info("memory_stats")
+	}
+
+	// Disk
+	vutil, err := disk.Usage("/var/dynamite")
+	if err != nil {
+		fmt.Println("Unable to retrieve disk usage stats.")
+		*quitting <- []byte("Health watcher exiting!!")
+		return 		
+	} else { 
+		log.WithFields(StructToMap(vutil)).WithField("path", "/var/dynamite").Info("disk_usage")
+	}
+
+	outil, err := disk.Usage("/opt/dynamite")
+	if err != nil {
+		fmt.Println("Unable to retrieve disk usage stats.")
+		*quitting <- []byte("Health watcher exiting!!")
+		return 		
+	} else { 
+		log.WithFields(StructToMap(outil)).WithField("path", "/opt/dynamite").Info("disk_usage")
+	}
+
+	sutil, err := disk.Usage("/")
+	if err != nil {
+		fmt.Println("Unable to retrieve disk usage stats.")
+		*quitting <- []byte("Health watcher exiting!!")
+		return 		
+	} else { 
+		log.WithFields(StructToMap(sutil)).WithField("path", "/").Info("disk_usage")
+	}
+}

--- a/pkg/watcher/health.go
+++ b/pkg/watcher/health.go
@@ -20,19 +20,19 @@ func WatchHealth(ctx context.Context, log *logging.Entry, quitting *chan []byte)
 	// start := time.Now()
 	hinfo, err := host.Info()
 	if err != nil {
-		log.WithField("error_msg", err.Error()).Error("host_info_error")
+		logging.LogEntry.WithField("pkg", "health").WithField("error_msg", err.Error()).Error("host_info_error")
 	} else {
 		log.WithFields(common.StructToMap(hinfo)).Info("host_info")
 	}
 	// CPU STATS
 	ccount, err := cpu.Counts(true)
 	if err != nil {
-		log.WithField("error_msg", err.Error()).Error("cpu_core_cnt_error")
+		logging.LogEntry.WithField("pkg", "health").WithField("error_msg", err.Error()).Error("cpu_core_cnt_error")
 	}
 
 	lavg, err := load.Avg()
 	if err != nil {
-		log.WithField("error_msg", err.Error()).Error("cpu_load_avg_error")
+		logging.LogEntry.WithField("pkg", "health").WithField("error_msg", err.Error()).Error("cpu_load_avg_error")
 	} else {
 		if ccount > 0 {
 			log.WithFields(common.StructToMap(lavg)).WithField("cpu_cores", ccount).Info("cpu_load_avg")
@@ -43,7 +43,7 @@ func WatchHealth(ctx context.Context, log *logging.Entry, quitting *chan []byte)
 
 	ctimes, err := cpu.Times(true)
 	if err != nil {
-		log.WithField("error_msg", err.Error()).Error("cpu_times_error")
+		logging.LogEntry.WithField("pkg", "health").WithField("error_msg", err.Error()).Error("cpu_times_error")
 	} else {
 		for _, v := range ctimes {
 			log.WithFields(common.StructToMap(v)).Info("cpu_times")
@@ -53,7 +53,7 @@ func WatchHealth(ctx context.Context, log *logging.Entry, quitting *chan []byte)
 	// Memory
 	mem, err := mem.VirtualMemory()
 	if err != nil {
-		log.WithField("error_msg", err.Error()).Error("ram_stats_error")
+		logging.LogEntry.WithField("pkg", "health").WithField("error_msg", err.Error()).Error("ram_stats_error")
 	} else {
 		log.WithFields(common.StructToMap(mem)).Info("memory_stats")
 	}
@@ -62,7 +62,7 @@ func WatchHealth(ctx context.Context, log *logging.Entry, quitting *chan []byte)
 	vpath := "/var/log/dynamite"
 	vutil, err := disk.Usage(vpath)
 	if err != nil {
-		log.WithField("error_msg", err.Error()).Error("disk_stats_error")
+		logging.LogEntry.WithField("pkg", "health").WithField("error_msg", err.Error()).Error("disk_stats_error")
 	} else {
 		log.WithFields(common.StructToMap(vutil)).WithField("path", vpath).Info("disk_usage")
 	}
@@ -70,14 +70,21 @@ func WatchHealth(ctx context.Context, log *logging.Entry, quitting *chan []byte)
 	opath := "/opt/dynamite"
 	outil, err := disk.Usage(opath)
 	if err != nil {
-		log.WithField("error_msg", err.Error()).Error("disk_stats_error")
+		logging.LogEntry.WithField("pkg", "health").WithField("error_msg", err.Error()).Error("disk_stats_error")
 	} else {
 		log.WithFields(common.StructToMap(outil)).WithField("path", opath).Info("disk_usage")
+		// if utilization is over DUThreshold
+		// check what percentage Zeek makes up of the consumed space
+		// if zeek is over its allocated percentage, start removing old dirs
+		// do until zeek is below its allocated percentage
+		// verify total utilization is below threshold
+		//  if its not, check suricata
+		//  if suri is over its threshold, see if there are archived eve files we can delete
 	}
 
 	sutil, err := disk.Usage("/")
 	if err != nil {
-		log.WithField("error_msg", err.Error()).Error("disk_stats_error")
+		logging.LogEntry.WithField("pkg", "health").WithField("error_msg", err.Error()).Error("disk_stats_error")
 	} else {
 		log.WithFields(common.StructToMap(sutil)).WithField("path", "/").Info("disk_usage")
 	}

--- a/pkg/watcher/nic_stats.go
+++ b/pkg/watcher/nic_stats.go
@@ -3,235 +3,236 @@ package watcher
 // monitor the Agent's health and performance
 
 import (
-    "net"
-    "os"
-    "os/exec"
-    "fmt"
-    "strings"
-    "errors"
-    "path/filepath"
-    "strconv"
-    "github.com/safchain/ethtool"
-    "dynamite_daemon_core/pkg/common"
+	"dynamite_daemon_core/pkg/common"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/safchain/ethtool"
 )
 
 var (
-    stats = map[string]struct{}{
-        "collisions": 		struct{}{},
-        "multicast":        struct{}{},
-        "rx_bytes":         struct{}{},
-        "rx_compressed":    struct{}{},
-        "rx_crc_errors":    struct{}{},
-        "rx_dropped":       struct{}{},
-        "rx_errors":        struct{}{},
-        "rx_fifo_errors":   struct{}{},
-        "rx_frame_errors":  struct{}{},
-        "rx_length_errors": struct{}{},
-        "rx_missed_errors": struct{}{},
-        "rx_nohandler":     struct{}{},
-        "rx_over_errors":   struct{}{},
-        "rx_packets":       struct{}{}}
+	stats = map[string]struct{}{
+		"collisions":       struct{}{},
+		"multicast":        struct{}{},
+		"rx_bytes":         struct{}{},
+		"rx_compressed":    struct{}{},
+		"rx_crc_errors":    struct{}{},
+		"rx_dropped":       struct{}{},
+		"rx_errors":        struct{}{},
+		"rx_fifo_errors":   struct{}{},
+		"rx_FrameErrors":   struct{}{},
+		"rx_length_errors": struct{}{},
+		"rx_missed_errors": struct{}{},
+		"rx_nohandler":     struct{}{},
+		"rx_over_errors":   struct{}{},
+		"rx_packets":       struct{}{}}
 )
 
+// Iface is a container for attributes and counters of given network interface.
 type Iface struct {
-    Name			string	`json:"name"`
-    Driver			string	`json:"driver"`
-    DrvVer			string	`json:"driver_ver"`
-    Link			bool	`json:"link"`
-    Collisions		int64  	`json:"collisions"`
-    Mulitcast		int64  	`json:"multicast"`
-    Bytes			int64  	`json:"bytes"`
-    Compressed		int64  	`json:"compressed"`
-    CRC_errors		int64  	`json:"crc_errors"`
-    Dropped			int64  	`json:"dropped"`
-    Errors			int64  	`json:"errors"`
-    FIFO_errors		int64  	`json:"fifo_errors"`
-    Frame_errors	int64  	`json:"frame_errors"`
-    Length_errors	int64  	`json:"length_errors"`
-    Missed_errors	int64  	`json:"missed_errors"`
-    NOHandler		int64  	`json:"nohandler"`
-    Over_errors		int64  	`json:"over_errors"`
-    Packets			int64  	`json:"packets"`
+	Name         string `json:"name"`
+	Driver       string `json:"driver"`
+	DrvVer       string `json:"driver_ver"`
+	Link         bool   `json:"link"`
+	Collisions   int64  `json:"collisions"`
+	Mulitcast    int64  `json:"multicast"`
+	Bytes        int64  `json:"bytes"`
+	Compressed   int64  `json:"compressed"`
+	CRCErrors    int64  `json:"crc_errors"`
+	Dropped      int64  `json:"dropped"`
+	Errors       int64  `json:"errors"`
+	FIFOErrors   int64  `json:"fifo_errors"`
+	FrameErrors  int64  `json:"FrameErrors"`
+	LengthErrors int64  `json:"length_errors"`
+	MissedErrors int64  `json:"missed_errors"`
+	NOHandler    int64  `json:"nohandler"`
+	OverErrors   int64  `json:"over_errors"`
+	Packets      int64  `json:"packets"`
 }
 
-// checks if a given interface is valid
+// Checks if a given interface is valid
 func isIface(i string) bool {
-    ifaces, err := net.Interfaces()
-    if err == nil {
-        for _, v := range ifaces {
-            if i == v.Name {
-                return true
-            }
-        }
-    } else {
-        fmt.Println("Interface validation error:", err)
-    }
-    return false
+	ifaces, err := net.Interfaces()
+	if err == nil {
+		for _, v := range ifaces {
+			if i == v.Name {
+				return true
+			}
+		}
+	} else {
+		fmt.Println("Interface validation error:", err)
+	}
+	return false
 }
 
-// function to validate given interface name and return 
-// a prepopulated Iface struct 
-func newIface(s string)(iface *Iface, err error) {
-    if isIface(s) {
-        iface = &Iface{Name:s}
-        return iface, nil
-    }
-    return nil, errors.New("invalid interface name")
+// function to validate given interface name and return
+// a prepopulated Iface struct
+func newIface(s string) (iface *Iface, err error) {
+	if isIface(s) {
+		iface = &Iface{Name: s}
+		return iface, nil
+	}
+	return nil, errors.New("invalid interface name")
 }
 
-// Method to update Iface stats using sysfs 
-func (iface *Iface) updateStats()(){
-    stats := readSysFS(iface.Name)
-    if stats != nil {
-        for k,v := range stats {
-            switch k {
-            case "collisions":
-                iface.Collisions = v
-                break
-            case "multicast":
-                iface.Mulitcast = v
-                break
-            case "rx_bytes":
-                iface.Bytes = v
-                break
-            case "rx_compressed":
-                break
-                iface.Compressed = v
-                break
-            case "rx_crc_errors":
-                iface.CRC_errors = v
-                break
-            case "rx_dropped":
-                iface.Dropped = v
-                break
-            case "rx_errors":
-                iface.Errors = v
-                break
-            case "rx_fifo_errors":
-                iface.FIFO_errors = v
-                break
-            case "rx_frame_errors":
-                iface.Frame_errors = v
-                break
-            case "rx_length_errors":
-                iface.Length_errors = v
-                break
-            case "rx_missed_errors":
-                iface.Missed_errors = v
-                break
-            case "rx_nohandler":
-                iface.NOHandler = v
-                break
-            case "rx_over_errors":
-                iface.Over_errors = v
-                break
-            case "rx_packets":
-                iface.Packets = v
-            }
-        }
-    }
-    return
+// Method to update Iface stats using sysfs
+func (iface *Iface) updateStats() {
+	stats := readSysFS(iface.Name)
+	if stats != nil {
+		for k, v := range stats {
+			switch k {
+			case "collisions":
+				iface.Collisions = v
+				break
+			case "multicast":
+				iface.Mulitcast = v
+				break
+			case "rx_bytes":
+				iface.Bytes = v
+				break
+			case "rx_compressed":
+				iface.Compressed = v
+				break
+			case "rx_crc_errors":
+				iface.CRCErrors = v
+				break
+			case "rx_dropped":
+				iface.Dropped = v
+				break
+			case "rx_errors":
+				iface.Errors = v
+				break
+			case "rx_fifo_errors":
+				iface.FIFOErrors = v
+				break
+			case "rx_FrameErrors":
+				iface.FrameErrors = v
+				break
+			case "rx_length_errors":
+				iface.LengthErrors = v
+				break
+			case "rx_missed_errors":
+				iface.MissedErrors = v
+				break
+			case "rx_nohandler":
+				iface.NOHandler = v
+				break
+			case "rx_over_errors":
+				iface.OverErrors = v
+				break
+			case "rx_packets":
+				iface.Packets = v
+			}
+		}
+	}
+	return
 }
 
 // takes an interface name and returns the available sysfs counters
 func readSysFS(ifname string) (ifrpt map[string]int64) {
-    ifrpt = make(map[string]int64)
-    if isIface(ifname) {
-        statspath := filepath.Join("/sys/class/net", ifname, "statistics")
-        avail := common.GetFileList(statspath)
-        if avail != nil {
-            for _, v := range avail {
-                if _, ok := stats[v]; ok {
-                    statpath := filepath.Join(statspath, v)
-                    val := runCMD("cat", []string{statpath})
-                    if val != "" {
-                        ival, err := strconv.ParseInt(strings.TrimSpace(val), 0, 64)
-                        if err != nil {
-                            fmt.Printf("Unable to parse stat %s: %v\n", v, err)
-                        } else {
-                            ifrpt[v] = ival
-                        }
-                    }
-                }
-            }
-        }
-    }
-    return
+	ifrpt = make(map[string]int64)
+	if isIface(ifname) {
+		statspath := filepath.Join("/sys/class/net", ifname, "statistics")
+		avail := common.GetFileList(statspath)
+		if avail != nil {
+			for _, v := range avail {
+				if _, ok := stats[v]; ok {
+					statpath := filepath.Join(statspath, v)
+					val := runCMD("cat", []string{statpath})
+					if val != "" {
+						ival, err := strconv.ParseInt(strings.TrimSpace(val), 0, 64)
+						if err != nil {
+							fmt.Printf("Unable to parse stat %s: %v\n", v, err)
+						} else {
+							ifrpt[v] = ival
+						}
+					}
+				}
+			}
+		}
+	}
+	return
 }
 
-// get interface link state 
-func (iface *Iface)getLinkStatus(e *ethtool.Ethtool)() {
-    ls, err := e.LinkState(iface.Name)
-    if err != nil {
-        iface.Link = false
-        return
-    }
-    if ls == 1 {
-        iface.Link = true
-    } else {
-        iface.Link = false
-    }
-    return 
+// get interface link state
+func (iface *Iface) getLinkStatus(e *ethtool.Ethtool) {
+	ls, err := e.LinkState(iface.Name)
+	if err != nil {
+		iface.Link = false
+		return
+	}
+	if ls == 1 {
+		iface.Link = true
+	} else {
+		iface.Link = false
+	}
+	return
 }
 
-// function to gather network interface info and stats 
-func GetEthInfo(i string)(iface *Iface) {
-    iface, err := newIface(i)
-    if err != nil {
-        return 
-    }
-    et, err := ethtool.NewEthtool()
-    if err != nil {
-        return
-    }
-    defer et.Close()
-    iface.getLinkStatus(et)
-    iface.getDriverInfo(et)
-    iface.updateStats()
-    return 
+// GetEthInfo gathers network interface info and stats for a given interface
+func GetEthInfo(i string) (iface *Iface) {
+	iface, err := newIface(i)
+	if err != nil {
+		return
+	}
+	et, err := ethtool.NewEthtool()
+	if err != nil {
+		return
+	}
+	defer et.Close()
+	iface.getLinkStatus(et)
+	iface.getDriverInfo(et)
+	iface.updateStats()
+	return
 }
 
-// get inteface driver name 
-func (iface *Iface)getDriverInfo(e *ethtool.Ethtool)() {
-    dinfo, err := e.DriverInfo(iface.Name)
-    if err != nil {
-        return 
-    }
-    if dinfo.Driver != "" {
-        iface.Driver = dinfo.Driver
-    }
-    if dinfo.Version != "" {
-        iface.DrvVer = dinfo.Version
-    }
-    return 
+// get inteface driver name
+func (iface *Iface) getDriverInfo(e *ethtool.Ethtool) {
+	dinfo, err := e.DriverInfo(iface.Name)
+	if err != nil {
+		return
+	}
+	if dinfo.Driver != "" {
+		iface.Driver = dinfo.Driver
+	}
+	if dinfo.Version != "" {
+		iface.DrvVer = dinfo.Version
+	}
+	return
 }
 
 // returns a list of files found in the given directory
 func getStatList(dir string) (files []string) {
-    f, err := os.Open(dir)
-    if err != nil {
-        return nil
-    }
-    dirlist, err := f.Readdir(-1)
-    f.Close()
-    if err != nil {
-        return nil
-    }
-    for _, e := range dirlist {
-        files = append(files, e.Name())
-    }
-    return
+	f, err := os.Open(dir)
+	if err != nil {
+		return nil
+	}
+	dirlist, err := f.Readdir(-1)
+	f.Close()
+	if err != nil {
+		return nil
+	}
+	for _, e := range dirlist {
+		files = append(files, e.Name())
+	}
+	return
 }
 
 // execute a given command, passing arguments.
 //returns stdout as a string or nil
 func runCMD(c string, args []string) (out string) {
-    cmd := exec.Command(c, args[:]...)
-    res, err := cmd.Output()
-    if err != nil {
-        out = ""
-    } else {
-        out = string(res)
-    }
-    return
+	cmd := exec.Command(c, args[:]...)
+	res, err := cmd.Output()
+	if err != nil {
+		out = ""
+	} else {
+		out = string(res)
+	}
+	return
 }

--- a/pkg/watcher/pruning.go
+++ b/pkg/watcher/pruning.go
@@ -1,0 +1,77 @@
+package watcher
+
+import "context"
+
+const (
+	agentMaxCap     = 90.0 // threshold where we start doing recovery pruning
+	agentTargetCap  = 80.0 // threshold we stay below in active pruning mode
+	zeekPercent     = 60.0 // percentage of available storage allocated to Zeek
+	suricataPercent = 30.0 // percentage of avaialble storage allocated to suricata alerts
+)
+
+var (
+	storageConsumptionRate = 0.0       // Current GB/day consumption rate
+	diskPercentPerDay      = 0.0       // Current disk utilization / day
+	daysUntilFull          = 10        // Estimated days remaining until pruning starts
+	pruneMode              = "recover" // Pruning mode, default is recover, config overrides this
+)
+
+// on agent's
+
+// StartPruning starts data pruning tasks on the Agent.
+func StartPruning(ctx context.Context) {
+	// watcher always does disk pruning on the agent
+	// this behavior can be disabled in the config file
+	return
+}
+
+// GetAgentDataCap returns the capacity of the data volume in use on the Agent
+func GetAgentDataCap() float64 {
+	return 0.0
+}
+
+// GetSuriUtil returns the current utilization of the data volume in use on the Agent
+func GetSuriUtil() float64 {
+	// Suri is a little different since it
+	// writes to a single log file and doesn't
+	// do any of its own rotation.
+	// We use logrotate to handle the
+	// rolling and archiving of old suricata
+	// alerts.
+
+	// here we are just verifying that its
+	// hapenning.  if we need to make room
+	// on the disk, we'll delete archived
+	// suri alert files, starting with the
+	// oldest.
+	return 0.0
+}
+
+// AgentAtCapacity returns true if critical disks/partitions are full
+func AgentAtCapacity() {
+	return
+}
+
+// PruneAgent removes old event/alert data from the Agent until it is no longer at capacity
+func PruneAgent(ctx context.Context) {
+	// job that gets executed regularly on the agent
+	// this monitors disk usage and if a threshold is
+	// crossed, begins to remove old archived zeek and
+	// suricata data
+
+	// check the mode
+	// if its active, need to be below the target cap
+	// if its recover, need to be below the max cap
+
+	// if we need to, start prunining
+
+	// find all the zeek data archives
+	// sort a slice, by last modify date
+	// start at the end,
+	// delete directory
+	// then check the current util
+	// rinse/repeat until below the cap
+
+	// update stats and checkpoints
+	return
+}

--- a/pkg/watcher/resources.go
+++ b/pkg/watcher/resources.go
@@ -1,280 +1,273 @@
 package watcher
 
 import (
-    "github.com/shirou/gopsutil/process"
-    "github.com/shirou/gopsutil/cpu"
-    "strings"
-    "dynamite_daemon_core/pkg/common"
+	"dynamite_daemon_core/pkg/common"
+	"strings"
+
+	"github.com/shirou/gopsutil/cpu"
+	"github.com/shirou/gopsutil/process"
 )
 
 var (
-    zeek_node_types = map[string]struct{}{
-        "manager" : struct{}{},
-        "proxy" : struct{}{},
-        "logger" : struct{}{},
-        "worker" : struct{}{},
-    }
+	zeekNodeTypes = map[string]struct{}{
+		"manager": struct{}{},
+		"proxy":   struct{}{},
+		"logger":  struct{}{},
+		"worker":  struct{}{},
+	}
 
-    cpu_stats = map[string]struct{}{
-        "user": struct{}{},
-        "system": struct{}{},
-        "idle": struct{}{},
-        "nice": struct{}{},
-        "iowait": struct{}{},
-        "irq": struct{}{},
-        "softirq": struct{}{},
-        "steal": struct{}{},
-        "guest": struct{}{},
-        "guestNice": struct{}{},
-    }
+	cpuStats = map[string]struct{}{
+		"user":      struct{}{},
+		"system":    struct{}{},
+		"idle":      struct{}{},
+		"nice":      struct{}{},
+		"iowait":    struct{}{},
+		"irq":       struct{}{},
+		"softirq":   struct{}{},
+		"steal":     struct{}{},
+		"guest":     struct{}{},
+		"guestNice": struct{}{},
+	}
 )
 
+// EngineStats is a container for resource utilization stats related to an inspection engine
 type EngineStats struct {
-    Engine		string 	    `json:"engine"`
-    ProcessCnt	int32	    `json:"proc_cnt"`
-    ThreadCnt	int32	    `json:"thread_cnt"`
-    CPU			float64	    `json:"pct_cpu"`
-    RAM			float32	    `json:"pct_ram"`
-    Files		int	        `json:"open_files"`
+	Engine     string  `json:"engine"`
+	ProcessCnt int32   `json:"proc_cnt"`
+	ThreadCnt  int32   `json:"thread_cnt"`
+	CPU        float64 `json:"pct_cpu"`
+	RAM        float32 `json:"pct_ram"`
+	Files      int     `json:"open_files"`
 }
 
+// ProcStats is a container for resource utilization stats related to a single inspection engine process
 type ProcStats struct {
-    Engine		string 	                `json:"engine"`
-    ProcName    string                  `json:"proc_name"`
-    NodeId      string                  `json:"node_id"`
-    PID			int32	                `json:"pid"`
-    PPID		int32	                `json:"ppid"`
-    CPUPct		float64	                `json:"pct_cpu"`
-    RAMPct		float32	                `json:"pct_ram"`
-    Files		int	                    `json:"open_files"`
-    Threads     int                     `json:"threads"`
-    Memory		*process.MemoryInfoStat `json:"memory"`
-    CPU			*cpu.TimesStat          `json:"cpu"`
+	Engine   string                  `json:"engine"`
+	ProcName string                  `json:"proc_name"`
+	NodeID   string                  `json:"node_id"`
+	PID      int32                   `json:"pid"`
+	PPID     int32                   `json:"ppid"`
+	CPUPct   float64                 `json:"pct_cpu"`
+	RAMPct   float32                 `json:"pct_ram"`
+	Files    int                     `json:"open_files"`
+	Threads  int                     `json:"threads"`
+	Memory   *process.MemoryInfoStat `json:"memory"`
+	CPU      *cpu.TimesStat          `json:"cpu"`
 }
 
+// ThreadStats is a contianer for resource utilization stats related to a single inspection engine thread
 type ThreadStats struct {
-    Engine		string 	                `json:"engine"`
-    ProcName    string                  `json:"proc_name"`
-    NodeId      string                  `json:"node_id"`
-    PID			int32			        `json:"pid"`
-    PPID		int32			        `json:"ppid"`
-    ThreadID    int32                   `json:"thread_id"`
-    PctIdle     float64                 `json:"pct_idle"`
-    PctBusy     float64                 `json:"pct_busy"`
-    TotalTime   float64                 `json:"total_time"`
-    CPU			*cpu.TimesStat 	        `json:"cpu"`
+	Engine    string         `json:"engine"`
+	ProcName  string         `json:"proc_name"`
+	NodeID    string         `json:"node_id"`
+	PID       int32          `json:"pid"`
+	PPID      int32          `json:"ppid"`
+	ThreadID  int32          `json:"thread_id"`
+	TotalTime float64        `json:"total_time"`
+	CPU       *cpu.TimesStat `json:"cpu"`
 }
 
+// AgentResourceReport is a container for managing
 type AgentResourceReport struct {
-    ZeekProcs   []*process.Process         `json:"zeek_procs"`
-    SuriProcs   []*process.Process         `json:"zeek_procs"`
-    EngRpts     []map[string]interface{}   `json:"engine_stats"`
-    ProcRpts    []map[string]interface{}   `json:"proc_stats"`
-    ThrdRpts    []map[string]interface{}   `json:"thread_stats"`
+	ZeekProcs []*process.Process       `json:"zeek_procs"`
+	SuriProcs []*process.Process       `json:"suri_procs"`
+	EngRpts   []map[string]interface{} `json:"engine_stats"`
+	ProcRpts  []map[string]interface{} `json:"proc_stats"`
+	ThrdRpts  []map[string]interface{} `json:"thread_stats"`
 }
 
-// Generate a new ResourceReport
+// NewRR generates a new AgentResourceReport instance
 func NewRR() (rpt AgentResourceReport) {
-    procs, err := process.Processes()
-    if err != nil {
-        return
-    }
-    for _,p := range procs {
-        if n, err := p.Name(); err == nil {
-            switch n {
-            case "Suricata-Main":
-                // found a Suri proc 
-                rpt.SuriProcs = append(rpt.SuriProcs, p)
-            case "bro":
-                // found a bro 2.x proc 
-                rpt.ZeekProcs = append(rpt.ZeekProcs, p)
-            case "zeek":
-                // found a zeek 3.x proc 
-                rpt.ZeekProcs = append(rpt.ZeekProcs, p)
-            }
-        }
-    }
-    return
+	procs, err := process.Processes()
+	if err != nil {
+		return
+	}
+	for _, p := range procs {
+		if n, err := p.Name(); err == nil {
+			switch n {
+			case "Suricata-Main":
+				// found a Suri proc
+				rpt.SuriProcs = append(rpt.SuriProcs, p)
+			case "bro":
+				// found a bro 2.x proc
+				rpt.ZeekProcs = append(rpt.ZeekProcs, p)
+			case "zeek":
+				// found a zeek 3.x proc
+				rpt.ZeekProcs = append(rpt.ZeekProcs, p)
+			}
+		}
+	}
+	return
 }
 
-// Extracts the node ID from the process command args 
-func getZeekNodeName(v *process.Process)(string) {
-    if cli, err := v.CmdlineSlice(); err == nil {
-        for idx, val := range cli {
-            if val == "-p" {
-                for t := range zeek_node_types {
-                    if strings.Contains(cli[idx+1], t) {
-                        return cli[idx+1]
-                    }
-                }
-            }
-        }
-    }
-    return ""
+// Extracts the node ID from the process command args
+func getZeekNodeName(v *process.Process) string {
+	if cli, err := v.CmdlineSlice(); err == nil {
+		for idx, val := range cli {
+			if val == "-p" {
+				for t := range zeekNodeTypes {
+					if strings.Contains(cli[idx+1], t) {
+						return cli[idx+1]
+					}
+				}
+			}
+		}
+	}
+	return ""
 }
 
-// Calculate %idle and %busy for each thread 
-func (tstats *ThreadStats) GetPctIdle() {
-    cpusmap := common.StructToMap(tstats.CPU)
-    var idl float64
-    tstats.TotalTime = tstats.CPU.Total()
-    for k,v := range cpusmap {
-        if _, ok := cpu_stats[k]; ok {
-            tstats.TotalTime += v.(float64) 
-            if k == "idle" {
-                idl = v.(float64)
-                break
-            }
-        }
-    }
-    tstats.PctIdle = idl/tstats.TotalTime
-    tstats.PctBusy = 100.00 - tstats.PctIdle
+// EngSummary returns aggregated stats for a given engine name
+func EngSummary(procs []*process.Process, name string) map[string]interface{} {
+	e := &EngineStats{Engine: name}
+	for _, v := range procs {
+		e.ProcessCnt++
+
+		t, err := v.NumThreads()
+		if err != nil {
+			continue
+		}
+		e.ThreadCnt += t
+
+		c, err := v.CPUPercent()
+		if err != nil {
+			continue
+		}
+		e.CPU += c
+
+		m, err := v.MemoryPercent()
+		if err != nil {
+			continue
+		}
+		e.RAM += m
+
+		f, err := v.OpenFiles()
+		if err != nil {
+			continue
+		}
+		e.Files += len(f)
+	}
+	return common.StructToMap(e)
 }
 
-// Collect aggregated stats for a given engine name 
-func EngSummary(procs []*process.Process, name string)(map[string]interface{}) {
-    e := &EngineStats{Engine : name}
-    for _,v := range procs {
-        e.ProcessCnt += 1
+// ProcSummary collects process-level stats for each engine
+func ProcSummary(procs []*process.Process, name string) (ps []map[string]interface{}) {
+	for _, proc := range procs {
+		p := &ProcStats{Engine: name}
 
-        t, err := v.NumThreads()
-        if err != nil { continue }
-        e.ThreadCnt += t
+		if name == "zeek" {
+			p.NodeID = getZeekNodeName(proc)
+		} else if name == "suricata" {
+			p.NodeID = "main"
+		}
 
-        c, err := v.CPUPercent()
-        if err != nil { continue }
-        e.CPU += c
+		if pn, err := proc.Name(); err == nil && pn != "" {
+			p.ProcName = pn
+		}
 
-        m, err := v.MemoryPercent()
-        if err != nil { continue }
-        e.RAM += m
+		p.PID = proc.Pid
 
-        f, err := v.OpenFiles()
-        if err != nil { continue }
-        e.Files += len(f)
-    }
-    return common.StructToMap(e)
+		if pp, err := proc.Ppid(); err == nil {
+			p.PPID = pp
+		}
+
+		if cp, err := proc.CPUPercent(); err == nil && cp != 0 {
+			p.CPUPct = cp
+		}
+
+		if rp, err := proc.MemoryPercent(); err == nil && rp != 0 {
+			p.RAMPct = rp
+		}
+
+		if of, err := proc.OpenFiles(); err == nil && of != nil {
+			p.Files = len(of)
+		}
+
+		if mi, err := proc.MemoryInfo(); err == nil && mi != nil {
+			p.Memory = mi
+		}
+
+		if cpu, err := proc.Times(); err == nil && cpu != nil {
+			p.CPU = cpu
+		}
+
+		p.Threads = 0
+		if thrds, err := proc.Threads(); err == nil && len(thrds) > 0 {
+			p.Threads = len(thrds)
+		}
+
+		ps = append(ps, common.StructToMap(p))
+	}
+	return
 }
 
-// collect process-level stats for each engine
-func ProcSummary(procs []*process.Process, name string)(ps []map[string]interface{}) {
-    for _, proc := range procs {
-        p := &ProcStats{Engine : name}
-        
-        if name == "zeek" {
-            p.NodeId = getZeekNodeName(proc)
-        } else if name == "suricata" {
-            p.NodeId = "main"
-        }
-        
-        if pn, err := proc.Name(); err == nil && pn != "" {
-            p.ProcName = pn
-        }
+// ThreadSummary collects thread-level stats for each engine, process
+func ThreadSummary(procs []*process.Process, name string) (ts []map[string]interface{}) {
+	for _, proc := range procs {
 
-        p.PID = proc.Pid
+		if thrds, err := proc.Threads(); err == nil && len(thrds) > 0 {
+			for id, thrd := range thrds {
+				p := &ThreadStats{Engine: name, ThreadID: id}
 
-        if pp, err := proc.Ppid(); err == nil {
-            p.PPID = pp 
-        }
+				if name == "zeek" {
+					p.NodeID = getZeekNodeName(proc)
+				} else if name == "suricata" {
+					p.NodeID = "main"
+				}
 
-        if cp, err := proc.CPUPercent(); err == nil && cp != 0 {
-            p.CPUPct = cp
-        }
+				if pn, err := proc.Name(); err == nil && pn != "" {
+					p.ProcName = pn
+				}
 
-        if rp, err := proc.MemoryPercent(); err == nil && rp != 0 {
-            p.RAMPct = rp
-        }
+				p.PID = proc.Pid
 
-        if of, err := proc.OpenFiles(); err == nil && of != nil {
-            p.Files = len(of)
-        }
-
-        if mi, err := proc.MemoryInfo(); err == nil && mi != nil {
-            p.Memory = mi
-        }
-
-        if cpu, err := proc.Times(); err == nil && cpu != nil {
-            p.CPU = cpu
-        }
-
-        p.Threads = 0
-        if thrds, err := proc.Threads(); err == nil && len(thrds) > 0 {
-            p.Threads = len(thrds)
-        }
-
-        ps = append(ps, common.StructToMap(p))
-    }
-    return     
+				if pp, err := proc.Ppid(); err == nil {
+					p.PPID = pp
+				}
+				p.CPU = thrd
+				ts = append(ts, common.StructToMap(p))
+			}
+		}
+	}
+	return
 }
 
-// collect thread-level stats for each engine, process 
-func ThreadSummary(procs []*process.Process, name string)(ts []map[string]interface{}) {
-    for _, proc := range procs {
-
-        if thrds, err := proc.Threads(); err == nil && len(thrds) > 0 {
-            for id, thrd := range thrds {
-                p := &ThreadStats{Engine : name, ThreadID : id}
-            
-                if name == "zeek" {
-                    p.NodeId = getZeekNodeName(proc)
-                } else if name == "suricata" {
-                    p.NodeId = "main"
-                }
-                
-                if pn, err := proc.Name(); err == nil && pn != "" {
-                    p.ProcName = pn
-                }
-        
-                p.PID = proc.Pid
-        
-                if pp, err := proc.Ppid(); err == nil {
-                    p.PPID = pp 
-                }
-                p.CPU = thrd
-                ts = append(ts, common.StructToMap(p))
-            }
-        } 
-    }
-    return     
+// RptAEngines stores a slice of engine stat reports in ResourceReport.EngRpts
+func (rpt *AgentResourceReport) RptAEngines() {
+	if rpt.ZeekProcs != nil && len(rpt.ZeekProcs) > 0 {
+		rpt.EngRpts = append(rpt.EngRpts, EngSummary(rpt.ZeekProcs, "zeek"))
+	}
+	if rpt.SuriProcs != nil && len(rpt.SuriProcs) > 0 {
+		rpt.EngRpts = append(rpt.EngRpts, EngSummary(rpt.SuriProcs, "suricata"))
+	}
+	return
 }
 
-// Stores a slice of engine stat reports in ResourceReport.EngRpts
-func (rpt *AgentResourceReport)RptAEngines()() {
-    if rpt.ZeekProcs != nil && len(rpt.ZeekProcs) > 0 {
-        rpt.EngRpts = append(rpt.EngRpts, EngSummary(rpt.ZeekProcs, "zeek"))
-    } 
-    if rpt.SuriProcs != nil && len(rpt.SuriProcs) > 0 {
-        rpt.EngRpts = append(rpt.EngRpts, EngSummary(rpt.SuriProcs, "suricata"))
-    } 
-    return 
+// RptAProcs stores a slice of process stat reports in ResourceReport.ProcRpts
+func (rpt *AgentResourceReport) RptAProcs() {
+	if rpt.ZeekProcs != nil && len(rpt.ZeekProcs) > 0 {
+		rpt.ProcRpts = append(rpt.ProcRpts, ProcSummary(rpt.ZeekProcs, "zeek")...)
+	}
+	if rpt.SuriProcs != nil && len(rpt.SuriProcs) > 0 {
+		rpt.ProcRpts = append(rpt.ProcRpts, ProcSummary(rpt.SuriProcs, "suricata")...)
+	}
+	return
 }
 
-// Stores a slice of process stat reports in ResourceReport.ProcRpts
-func (rpt *AgentResourceReport)RptAProcs()() {
-    if rpt.ZeekProcs != nil && len(rpt.ZeekProcs) > 0 {
-        rpt.ProcRpts = append(rpt.ProcRpts, ProcSummary(rpt.ZeekProcs, "zeek")...)
-    } 
-    if rpt.SuriProcs != nil && len(rpt.SuriProcs) > 0 {
-        rpt.ProcRpts = append(rpt.ProcRpts, ProcSummary(rpt.SuriProcs, "suricata")...)
-    } 
-    return 
-}
-
-// Stores a slice of thread stat reports in ResourceReport.ThrdRpts
-func (rpt *AgentResourceReport)RptAThreads()() {
-    if rpt.ZeekProcs != nil && len(rpt.ZeekProcs) > 0 {
-        for _, v := range ThreadSummary(rpt.ZeekProcs, "zeek") {
-            if len(v) > 0 {
-                rpt.ThrdRpts = append(rpt.ThrdRpts, v)
-            }
-        }
-    } 
-    if rpt.SuriProcs != nil && len(rpt.SuriProcs) > 0 {
-        for _,v := range ThreadSummary(rpt.SuriProcs, "suricata") {
-            if len(v) > 0 {
-                rpt.ThrdRpts = append(rpt.ThrdRpts, v)
-            }
-        }
-    } 
-    return 
+// RptAThreads stores a slice of thread stat reports in ResourceReport.ThrdRpts
+func (rpt *AgentResourceReport) RptAThreads() {
+	if rpt.ZeekProcs != nil && len(rpt.ZeekProcs) > 0 {
+		for _, v := range ThreadSummary(rpt.ZeekProcs, "zeek") {
+			if len(v) > 0 {
+				rpt.ThrdRpts = append(rpt.ThrdRpts, v)
+			}
+		}
+	}
+	if rpt.SuriProcs != nil && len(rpt.SuriProcs) > 0 {
+		for _, v := range ThreadSummary(rpt.SuriProcs, "suricata") {
+			if len(v) > 0 {
+				rpt.ThrdRpts = append(rpt.ThrdRpts, v)
+			}
+		}
+	}
+	return
 }

--- a/pkg/watcher/suricata.go
+++ b/pkg/watcher/suricata.go
@@ -3,23 +3,24 @@
 package watcher
 
 import (
-	"gopkg.in/yaml.v2"
+	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"reflect"
-	"errors"
-	"fmt"
+
+	"gopkg.in/yaml.v2"
 )
 
-// Struct to hold Suricata threading settings
+// SuriConf is a struct containing Suricata's threading settings
 type SuriConf struct {
-	MgrCPUS     	[]int   	`json:"suri_mgr_cpus"`
-	RcvCPUS     	[]int   	`json:"suri_rcv_cpus"`
-	WrkCPUS     	[]int   	`json:"suri_wrk_cpus"`
-	DTR         	float64 	`json:"suri_dtr"`
-	UseAffinity 	bool    	`json:"suri_pin_cpus"`
-	RunMode     	string  	`json:"suri_runmode"`
-	Ifaces			[]string 	`json:"suri_ifaces"`
+	MgrCPUS     []int    `json:"suri_mgr_cpus"`
+	RcvCPUS     []int    `json:"suri_rcv_cpus"`
+	WrkCPUS     []int    `json:"suri_wrk_cpus"`
+	DTR         float64  `json:"suri_dtr"`
+	UseAffinity bool     `json:"suri_pin_cpus"`
+	RunMode     string   `json:"suri_runmode"`
+	Ifaces      []string `json:"suri_ifaces"`
 }
 
 // Variables used in this package
@@ -27,7 +28,7 @@ var (
 	SuriConfFile = "/etc/dynamite/suricata/suricata.yaml"
 )
 
-// Function to parse threading settings from Suricata yaml
+// GetSuriConf retrieves threading settings from Suricata yaml
 func GetSuriConf() (*SuriConf, error) {
 	var sconf SuriConf
 	if _, err := os.Stat(SuriConfFile); os.IsNotExist(err) {
@@ -37,7 +38,7 @@ func GetSuriConf() (*SuriConf, error) {
 
 	scfile, err := ioutil.ReadFile(SuriConfFile)
 	if err != nil {
-		msg := fmt.Sprintf("Failed to open Suricata config file, e: %v")
+		msg := fmt.Sprintf("Failed to open Suricata config file, e: %v", err)
 		return &sconf, errors.New(msg)
 	}
 
@@ -81,7 +82,7 @@ func GetSuriConf() (*SuriConf, error) {
 								if k.(string) == "cpu" {
 									if reflect.TypeOf(v).String() == "[]interface {}" {
 										for c := range v.([]interface{}) {
-											sconf.MgrCPUS = append(sconf.MgrCPUS, c)									
+											sconf.MgrCPUS = append(sconf.MgrCPUS, c)
 										}
 									} else if reflect.TypeOf(v).String() == "int" {
 										sconf.MgrCPUS = append(sconf.MgrCPUS, v.(int))
@@ -96,20 +97,20 @@ func GetSuriConf() (*SuriConf, error) {
 									if reflect.TypeOf(v).String() == "[]interface {}" {
 										for c := range v.([]interface{}) {
 											sconf.RcvCPUS = append(sconf.RcvCPUS, c)
-											}
 										}
-									} else if reflect.TypeOf(v).String() == "int" {
-										sconf.RcvCPUS = append(sconf.RcvCPUS, v.(int))
 									}
+								} else if reflect.TypeOf(v).String() == "int" {
+									sconf.RcvCPUS = append(sconf.RcvCPUS, v.(int))
 								}
 							}
+						}
 						if k.(string) == "worker-cpu-set" {
 							for k, v := range v.(map[interface{}]interface{}) {
 								if k.(string) == "cpu" {
 									if reflect.TypeOf(v).String() == "[]interface {}" {
 										for c := range v.([]interface{}) {
 											sconf.WrkCPUS = append(sconf.WrkCPUS, c)
-											}
+										}
 									} else if reflect.TypeOf(v).String() == "int" {
 										sconf.WrkCPUS = append(sconf.WrkCPUS, v.(int))
 									}

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -35,6 +35,10 @@ func Init(ctx context.Context) {
 		}
 	}
 
+	hlog, hlogger := logging.Configure("health")
+	worker.Add(ctx, WatchHealth, &hlog, interval, &quitting)
+	loggers = append(loggers, &hlogger)
+
 	if conf.Conf.HasRole("agent") {
 		// run Agent monitoring tasks 
 		alog, alogger := logging.Configure("agent")

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -2,21 +2,21 @@ package watcher
 
 import (
 	"context"
-	"time"
 	"fmt"
+	"time"
 
 	// Dynamite
-	"dynamite_daemon_core/pkg/logging"
+	"dynamite_daemon_core/pkg/common"
 	"dynamite_daemon_core/pkg/conf"
-	. "dynamite_daemon_core/pkg/common"
+	"dynamite_daemon_core/pkg/logging"
 )
 
 var (
-	log *logging.Entry
-	logger *logging.Logger
-	exit = make(chan []byte)
+	log      *logging.Entry
+	logger   *logging.Logger
+	exit     = make(chan []byte)
 	quitting = make(chan []byte)
-	running = 0
+	running  = 0
 )
 
 // Init is called explicitly
@@ -24,14 +24,14 @@ func Init(ctx context.Context) {
 	var loggers []*logging.Logger
 
 	interval := 60 * time.Second
-	worker := NewScheduler()
+	worker := common.NewScheduler()
 	if conf.Conf.Watcher.Interval != "" {
-		watchInt, err := ParseDuration(conf.Conf.Watcher.Interval)
+		watchInt, err := common.ParseDuration(conf.Conf.Watcher.Interval)
 		if err == nil && watchInt != 0 {
 			interval = watchInt
 		} else {
 			fmt.Println("Invalid Watcher interval:", err)
-			
+
 		}
 	}
 
@@ -40,22 +40,26 @@ func Init(ctx context.Context) {
 	loggers = append(loggers, &hlogger)
 
 	if conf.Conf.HasRole("agent") {
-		// run Agent monitoring tasks 
+		// run Agent monitoring tasks
 		alog, alogger := logging.Configure("agent")
 		worker.Add(ctx, WatchAgent, &alog, interval, &quitting)
 		loggers = append(loggers, &alogger)
+
+		// if pruning not disabled, add an Agent pruning job
+		// log messages get written to health.jsonl
+		// this should have its own interval...
 	}
 	running = worker.Count()
-	
+
 	go keepWatch()
-	go Cleanup("watcher", loggers, &exit, worker)
+	go common.Cleanup("watcher", loggers, &exit, worker)
 	return
 }
 
-// keepWatch monitors the quitting channel for messages indicating a job is exiting early 
-// It's main job is to keep track of the running watcher jobs and signal an exit if they 
-// terminate early.   
-func keepWatch(){
+// keepWatch monitors the quitting channel for messages indicating a job is exiting early
+// It's main job is to keep track of the running watcher jobs and signal an exit if they
+// all terminate for some reason.
+func keepWatch() {
 	for {
 		select {
 		case msg := <-quitting:

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -63,7 +63,7 @@ func keepWatch() {
 	for {
 		select {
 		case msg := <-quitting:
-			log.WithField("error_msg", msg).Error("watcher_job_failed")
+			logging.LogEntry.WithField("pkg", "watcher").WithField("error_msg", msg).Error("watcher_job_failed")
 			running = running - 1
 			if running <= 0 {
 				exit <- []byte("all watcher jobs failed")

--- a/pkg/watcher/zeek.go
+++ b/pkg/watcher/zeek.go
@@ -3,31 +3,33 @@
 package watcher
 
 import (
-	"strconv"
-	"strings"
 	"errors"
 	"fmt"
-	
+	"strconv"
+	"strings"
+
 	"gopkg.in/ini.v1"
 )
 
+// ZeekConf is a struct that contains Zeek's network interface and processor settings
 type ZeekConf struct {
-	MgrCPUS  []int  `json:"zeek_mgr_cpus"`
-	PrxCPUS  []int  `json:"zeek_prx_cpus"`
-	WrkCPUS  []int  `json:"zeek_wrk_cpus"`
-	WrkProcs int    `json:"zeek_lb_procs"`
-	LBMeth   string `json:"zeek_lb_method"`
+	MgrCPUS  []int    `json:"zeek_mgr_cpus"`
+	PrxCPUS  []int    `json:"zeek_prx_cpus"`
+	WrkCPUS  []int    `json:"zeek_wrk_cpus"`
+	WrkProcs int      `json:"zeek_lb_procs"`
+	LBMeth   string   `json:"zeek_lb_method"`
 	Ifaces   []string `json:"zeek_ifaces"`
 }
 
-var ZeekNodeConfFile string = "/opt/dynamite/zeek/etc/node.cfg"
+var zeekNodeConfig string = "/opt/dynamite/zeek/etc/node.cfg"
 
+// GetZeekConf parses the Zeek node config and returns a populated ZeekConf struct
 func GetZeekConf() (*ZeekConf, error) {
 	// Initialize a new container
 	var zconf ZeekConf
 
 	// open file as ini
-	cfg, err := ini.Load(ZeekNodeConfFile)
+	cfg, err := ini.Load(zeekNodeConfig)
 	if err != nil {
 		msg := fmt.Sprintf("Fail to read Zeek conf file: %v", err)
 		return &zconf, errors.New(msg)
@@ -49,15 +51,15 @@ func GetZeekConf() (*ZeekConf, error) {
 				}
 			}
 
-			if lb_procs, ok := k["lb_procs"]; ok {
-				v, err := strconv.Atoi(lb_procs)
+			if LBProcs, ok := k["lb_procs"]; ok {
+				v, err := strconv.Atoi(LBProcs)
 				if err == nil {
 					zconf.WrkProcs = v
 				}
 			}
 
-			if lb_meth, ok := k["lb_method"]; ok {
-				zconf.LBMeth = lb_meth
+			if LBMethod, ok := k["lb_method"]; ok {
+				zconf.LBMeth = LBMethod
 			}
 
 			if iface, ok := k["interface"]; ok {


### PR DESCRIPTION
This PR primarily adds the health and dynamited log streams.  It also handles a ton of linter findings.  

The watcher pkg now monitors and logs system-wide resource utilization.  This currently includes cpu load average, memory and disk utilization.  

We now also create a dynamited.jsonl log that contains any dynamited-level events or any other task management activities that reflect on dynamited's runtime state.  This is the log most error and debug messages should be sent to. 

dynamited still writes process state events to stdout which are turn captured by systemd and routed to the local syslog receiver.  They will show up in journal for the dynamited service as well as the syslog or messages file used by the OS. 

We also now create a log file for each configured role.  The agent.jsonl log contains all agent-specific monitoring information, including inspection interface stats, as well as zeek/suricata engine, process and thread-level stats.  Likewise, monitor.jsonl will have monitor-relevant stats.  